### PR TITLE
Changes to readme and installation requirements. Remove unused imports.

### DIFF
--- a/.detignore
+++ b/.detignore
@@ -1,3 +1,4 @@
 checkpoints
 datasets
 sample_images
+runs

--- a/.detignore
+++ b/.detignore
@@ -1,0 +1,3 @@
+checkpoints
+datasets
+sample_images

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__
+checkpoints
+datasets
+sample_images
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ checkpoints
 datasets
 sample_images
 .env
+runs

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Example of training a computer vision model on the MedMNIST dataset using Determ
 
 ## Changing the dataset
   #### For training purposes
-  1) Replace `data_flag` in `config.yaml` with the corresponding data flag. Full list can be found [here](https://github.com/MedMNIST/MedMNIST/blob/main/medmnist/info.py).
-  2) Download the desired corresponding dataset from [Zenodo](https://zenodo.org/record/6496656). Upload this to your S3 bucket and update the bucket details in `config.yaml`.
-  3) Update  `dataset_name ` in `config.yaml` to the name of this file.
+  1) Replace `data_flag` in `config.yaml` with the name of a MedMNIST subset. The subset names are listed [here](https://github.com/MedMNIST/MedMNIST/blob/main/medmnist/info.py), in the `INFO` variable. For example, `pathmnist` is one of the subset names.
   
   #### For inference purposes
   1) Copy the example environment file `.env_example` to `.env `.
@@ -18,15 +16,6 @@ Example of training a computer vision model on the MedMNIST dataset using Determ
   
       export DET_MASTER=<your_desired_master_ip>
 
-  Set up a python virtual environment and activate it:
-    
-      python3 -m venv ~/.myvenv
-      source ~/.myvenv/bin/activate
-
-  Install requirements:
-  
-      pip install -r requirements.txt
-
   Submit an experiment:
     
       det e create config.yaml .
@@ -34,11 +23,15 @@ Example of training a computer vision model on the MedMNIST dataset using Determ
 
 ## Running inference
 
+  Install requirements:
+  
+      pip install -r inference_requirements.txt
+
   Copy the example environment file `.env_example` to `.env `.
 
       cp .env_example .env
    
-  Change `EXPERIMENT_ID` to your experiment ID from your training run:
+  In the `.env` file, change `EXPERIMENT_ID` to your experiment ID from your training run:
     
       EXPERIMENT_ID=<your_experiment_ID>
       

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,14 @@ hyperparameters:
         base: 10
         minval: -4
         maxval: -1
+    beta1:
+        type: double
+        minval: 0.1
+        maxval: 0.999
+    beta2:
+        type: double
+        minval: 0.1
+        maxval: 0.999
     gamma: 0.1
 # data:
 #   url: https://medmnist-pathmnist.s3.us-east-2.amazonaws.com/pathmnist.npz

--- a/config.yaml
+++ b/config.yaml
@@ -2,15 +2,14 @@ name: pathmnist_const
 hyperparameters:
     global_batch_size: 128
     data_flag: pathmnist
-    dataset_name: "pathmnist.npz"
     model_flag: resnet18
     lr: 0.001
     gamma: 0.1
     resize: True
     task: "multi-class"
     num_epochs: 15
-data:
-  url: https://medmnist-pathmnist.s3.us-east-2.amazonaws.com/pathmnist.npz
+# data:
+#   url: https://medmnist-pathmnist.s3.us-east-2.amazonaws.com/pathmnist.npz
 records_per_epoch: 89996 
 searcher:
     name: single
@@ -18,8 +17,8 @@ searcher:
     smaller_is_better: false
     max_length: 
       epochs: 15
-resources:
-    slots_per_trial: 2
+# resources:
+    # slots_per_trial: 2
 entrypoint: model_def:MyMEDMnistTrial
 max_restarts: 0
 checkpoint_policy: all

--- a/config.yaml
+++ b/config.yaml
@@ -1,24 +1,32 @@
-name: pathmnist_const
+name: retinamnist_const
 hyperparameters:
     global_batch_size: 128
-    data_flag: pathmnist
+    data_flag: retinamnist
     model_flag: resnet18
-    lr: 0.001
+    lr:
+        type: log
+        base: 10
+        minval: -5
+        maxval: 0
     gamma: 0.1
-    resize: True
+    resize: False
     task: "multi-class"
     num_epochs: 15
 # data:
 #   url: https://medmnist-pathmnist.s3.us-east-2.amazonaws.com/pathmnist.npz
-records_per_epoch: 89996 
+min_validation_period:
+    epochs: 1
+records_per_epoch: 1080 
 searcher:
-    name: single
+    name: adaptive_asha
     metric: test_loss
-    smaller_is_better: false
+    smaller_is_better: true
     max_length: 
       epochs: 15
-# resources:
-    # slots_per_trial: 2
+    max_trials: 16
+    mode: aggressive
+resources:
+    slots_per_trial: 2
 entrypoint: model_def:MyMEDMnistTrial
 max_restarts: 0
 checkpoint_policy: all

--- a/config.yaml
+++ b/config.yaml
@@ -2,16 +2,13 @@ name: retinamnist_const
 hyperparameters:
     global_batch_size: 128
     data_flag: retinamnist
-    model_flag: resnet18
-    lr:
+    lr: 0.001
+    weight_decay:
         type: log
         base: 10
-        minval: -5
-        maxval: 0
+        minval: -4
+        maxval: -1
     gamma: 0.1
-    resize: False
-    task: "multi-class"
-    num_epochs: 15
 # data:
 #   url: https://medmnist-pathmnist.s3.us-east-2.amazonaws.com/pathmnist.npz
 min_validation_period:
@@ -29,6 +26,5 @@ resources:
     slots_per_trial: 2
 entrypoint: model_def:MyMEDMnistTrial
 max_restarts: 0
-checkpoint_policy: all
 
 

--- a/deploy.py
+++ b/deploy.py
@@ -8,11 +8,13 @@ from determined import pytorch
 from determined.experimental import client
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request
+from medmnist import INFO
 from PIL import Image
 
 app = Flask(__name__)
 
 load_dotenv()
+data_flag = os.getenv("DATA_FLAG")
 
 # Load the Determined model
 checkpoint = client.get_experiment(os.getenv("EXPERIMENT_ID")).top_checkpoint()
@@ -76,21 +78,11 @@ def predict():
     output_array = probabilities.detach().numpy()
 
     # Get the predicted class label
-    class_label = np.argmax(output_array)
-    class_labels = [
-        "adipose",
-        "background",
-        "debris",
-        "lymphocytes",
-        "mucus",
-        "smooth muscle",
-        "normal colon mucosa",
-        "cancer-associated stroma",
-        "colorectal adenocarcinoma epithelium",
-    ]
+    predicted_int = np.argmax(output_array)
+    prediction = INFO[data_flag]["label"][str(predicted_int)]
 
     # Return the predicted class label as a JSON response
-    return jsonify({"prediction": class_labels[class_label]})
+    return jsonify({"prediction": prediction})
 
 
 # Start the Flask server

--- a/deploy.py
+++ b/deploy.py
@@ -1,4 +1,5 @@
 import io
+import os
 
 import medmnist
 import numpy as np
@@ -10,12 +11,11 @@ import torch.utils.data as data
 import torchvision.transforms as transforms
 from determined import pytorch
 from determined.experimental import client
+from dotenv import load_dotenv
 from flask import Flask, jsonify, request
 from medmnist import INFO, Evaluator
 from PIL import Image
 from tqdm import tqdm
-from dotenv import load_dotenv
-import os
 
 app = Flask(__name__)
 
@@ -24,7 +24,10 @@ load_dotenv()
 # Load the Determined model
 checkpoint = client.get_experiment(os.getenv("EXPERIMENT_ID")).top_checkpoint()
 path = checkpoint.download()
-trial = pytorch.load_trial_from_checkpoint_path(path)
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+trial = pytorch.load_trial_from_checkpoint_path(
+    path, torch_load_kwargs={"map_location": device}
+)
 model = trial.model
 model.eval()
 

--- a/deploy.py
+++ b/deploy.py
@@ -1,21 +1,14 @@
 import io
 import os
 
-import medmnist
 import numpy as np
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
-import torch.optim as optim
-import torch.utils.data as data
-import torchvision.transforms as transforms
 from determined import pytorch
 from determined.experimental import client
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request
-from medmnist import INFO, Evaluator
 from PIL import Image
-from tqdm import tqdm
 
 app = Flask(__name__)
 

--- a/generate_sample_test_images.py
+++ b/generate_sample_test_images.py
@@ -13,7 +13,6 @@ load_dotenv()
 # global variables
 data_flag = os.getenv("DATA_FLAG")
 info = INFO[data_flag]
-task = info["task"]
 download = True
 root = "datasets"
 BATCH_SIZE = 128

--- a/generate_sample_test_images.py
+++ b/generate_sample_test_images.py
@@ -2,15 +2,10 @@ import os
 
 import medmnist
 import numpy as np
-import torch
-import torch.nn as nn
-import torch.optim as optim
 import torch.utils.data as data
 import torchvision.transforms as transforms
-from determined import pytorch
-from determined.experimental import client
 from dotenv import load_dotenv
-from medmnist import INFO, Evaluator
+from medmnist import INFO
 from PIL import Image
 
 load_dotenv()

--- a/inference_requirements.txt
+++ b/inference_requirements.txt
@@ -1,6 +1,4 @@
 medmnist
-tensorboardX
-wget
 python-dotenv
 determined
 flask

--- a/inference_requirements.txt
+++ b/inference_requirements.txt
@@ -1,4 +1,5 @@
 medmnist
+wget
 python-dotenv
 determined
 flask

--- a/model_def.py
+++ b/model_def.py
@@ -1,30 +1,21 @@
-import argparse
 import os
-import time
-from collections import OrderedDict
 from typing import Any, Dict, Sequence, Union
 
 import determined
 import medmnist
-import numpy as np
 import PIL
 import torch
 import torch.nn as nn
-import torch.optim as optim
-import torch.utils.data as data
 import torchvision.transforms as transforms
 import wget
-from determined.experimental import client
 from determined.pytorch import (
     DataLoader,
     LRScheduler,
     PyTorchTrial,
     PyTorchTrialContext,
 )
-from medmnist import INFO, Evaluator
-from tensorboardX import SummaryWriter
+from medmnist import INFO
 from torchvision.models import resnet18, resnet50
-from tqdm import trange
 
 TorchData = Union[Dict[str, torch.Tensor], Sequence[torch.Tensor], torch.Tensor]
 DATASET_ROOT = "datasets"
@@ -35,7 +26,6 @@ class MyMEDMnistTrial(PyTorchTrial):
         self.context = context
 
         self.info = INFO[self.context.get_hparam("data_flag")]
-        task = self.info["task"]
         n_classes = len(self.info["label"])
 
         self.context = context

--- a/model_def.py
+++ b/model_def.py
@@ -25,11 +25,10 @@ from medmnist import INFO, Evaluator
 from tensorboardX import SummaryWriter
 from torchvision.models import resnet18, resnet50
 from tqdm import trange
-from dotenv import load_dotenv
 
 TorchData = Union[Dict[str, torch.Tensor], Sequence[torch.Tensor], torch.Tensor]
 DATASET_ROOT = "datasets"
-load_dotenv()
+
 
 class MyMEDMnistTrial(PyTorchTrial):
     def __init__(self, context: PyTorchTrialContext) -> None:
@@ -73,10 +72,15 @@ class MyMEDMnistTrial(PyTorchTrial):
         )
 
         os.makedirs(DATASET_ROOT, exist_ok=True)
-        wget.download(
-            context.get_data_config()["url"],
-            out=os.path.join(DATASET_ROOT, self.context.get_hparam("dataset_name")),
-        )
+
+        data_url = context.get_data_config().get("url")
+        if data_url:
+            wget.download(
+                data_url,
+                out=os.path.join(
+                    DATASET_ROOT, f"{self.context.get_hparam('data_flag')}.npz"
+                ),
+            )
 
     def build_training_data_loader(self) -> DataLoader:
         DataClass = getattr(medmnist, self.info["python_class"])
@@ -97,7 +101,7 @@ class MyMEDMnistTrial(PyTorchTrial):
         train_dataset = DataClass(
             split="train",
             transform=data_transform,
-            download=False,
+            download=True,
             as_rgb=True,
             root=DATASET_ROOT,
         )
@@ -128,7 +132,7 @@ class MyMEDMnistTrial(PyTorchTrial):
         val_dataset = DataClass(
             split="val",
             transform=data_transform,
-            download=False,
+            download=True,
             as_rgb=True,
             root=DATASET_ROOT,
         )

--- a/model_def.py
+++ b/model_def.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Sequence, Union
 
 import determined
 import medmnist
-import PIL
 import torch
 import torch.nn as nn
 import torchvision.transforms as transforms
@@ -15,7 +14,6 @@ from determined.pytorch import (
     PyTorchTrialContext,
 )
 from medmnist import INFO
-from torchvision.models import resnet18, resnet50
 
 TorchData = Union[Dict[str, torch.Tensor], Sequence[torch.Tensor], torch.Tensor]
 DATASET_ROOT = "datasets"
@@ -26,32 +24,29 @@ class MyMEDMnistTrial(PyTorchTrial):
         self.context = context
 
         self.info = INFO[self.context.get_hparam("data_flag")]
+        n_channels = self.info["n_channels"]
         n_classes = len(self.info["label"])
+        task = self.info["task"]
 
-        self.context = context
-        if self.context.get_hparam("model_flag") == "resnet18":
-            model = resnet18(pretrained=False, num_classes=n_classes)
-        elif self.context.get_hparam("model_flag") == "resnet50":
-            model = resnet50(pretrained=False, num_classes=n_classes)
-        else:
-            raise NotImplementedError
-
+        model = Net(n_channels, n_classes)
         self.model = self.context.wrap_model(model)
 
         optimizer = torch.optim.Adam(
-            self.model.parameters(), lr=self.context.get_hparam("lr")
+            self.model.parameters(),
+            lr=self.context.get_hparam("lr"),
+            weight_decay=self.context.get_hparam("weight_decay"),
         )
         self.optimizer = self.context.wrap_optimizer(optimizer)
 
-        if self.context.get_hparam("task") == "multi-label, binary-class":
+        if task == "multi-label, binary-class":
             self.criterion = nn.BCEWithLogitsLoss()
         else:
             self.criterion = nn.CrossEntropyLoss()
 
-        milestones = [
-            0.5 * context.get_hparam("num_epochs"),
-            0.75 * context.get_hparam("num_epochs"),
+        num_epochs = self.context.get_experiment_config()["searcher"]["max_length"][
+            "epochs"
         ]
+        milestones = [0.5 * num_epochs, 0.75 * num_epochs]
         scheduler = torch.optim.lr_scheduler.MultiStepLR(
             self.optimizer,
             milestones=milestones,
@@ -74,19 +69,9 @@ class MyMEDMnistTrial(PyTorchTrial):
 
     def build_training_data_loader(self) -> DataLoader:
         DataClass = getattr(medmnist, self.info["python_class"])
-
-        if self.context.get_hparam("resize"):
-            data_transform = transforms.Compose(
-                [
-                    transforms.Resize((224, 224), interpolation=PIL.Image.NEAREST),
-                    transforms.ToTensor(),
-                    transforms.Normalize(mean=[0.5], std=[0.5]),
-                ]
-            )
-        else:
-            data_transform = transforms.Compose(
-                [transforms.ToTensor(), transforms.Normalize(mean=[0.5], std=[0.5])]
-            )
+        data_transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize(mean=[0.5], std=[0.5])]
+        )
 
         train_dataset = DataClass(
             split="train",
@@ -105,19 +90,9 @@ class MyMEDMnistTrial(PyTorchTrial):
 
     def build_validation_data_loader(self) -> DataLoader:
         DataClass = getattr(medmnist, self.info["python_class"])
-
-        if self.context.get_hparam("resize"):
-            data_transform = transforms.Compose(
-                [
-                    transforms.Resize((224, 224), interpolation=PIL.Image.NEAREST),
-                    transforms.ToTensor(),
-                    transforms.Normalize(mean=[0.5], std=[0.5]),
-                ]
-            )
-        else:
-            data_transform = transforms.Compose(
-                [transforms.ToTensor(), transforms.Normalize(mean=[0.5], std=[0.5])]
-            )
+        data_transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize(mean=[0.5], std=[0.5])]
+        )
 
         val_dataset = DataClass(
             split="val",
@@ -169,3 +144,53 @@ class MyMEDMnistTrial(PyTorchTrial):
             targets = targets.float().resize_(len(targets), 1)
 
         return {"test_loss": loss}
+
+
+# from https://github.com/MedMNIST/MedMNIST/blob/main/examples/getting_started.ipynb
+class Net(nn.Module):
+    def __init__(self, in_channels, num_classes):
+        super().__init__()
+
+        self.layer1 = nn.Sequential(
+            nn.Conv2d(in_channels, 16, kernel_size=3), nn.BatchNorm2d(16), nn.ReLU()
+        )
+
+        self.layer2 = nn.Sequential(
+            nn.Conv2d(16, 16, kernel_size=3),
+            nn.BatchNorm2d(16),
+            nn.ReLU(),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+        )
+
+        self.layer3 = nn.Sequential(
+            nn.Conv2d(16, 64, kernel_size=3), nn.BatchNorm2d(64), nn.ReLU()
+        )
+
+        self.layer4 = nn.Sequential(
+            nn.Conv2d(64, 64, kernel_size=3), nn.BatchNorm2d(64), nn.ReLU()
+        )
+
+        self.layer5 = nn.Sequential(
+            nn.Conv2d(64, 64, kernel_size=3, padding=1),
+            nn.BatchNorm2d(64),
+            nn.ReLU(),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+        )
+
+        self.fc = nn.Sequential(
+            nn.Linear(64 * 4 * 4, 128),
+            nn.ReLU(),
+            nn.Linear(128, 128),
+            nn.ReLU(),
+            nn.Linear(128, num_classes),
+        )
+
+    def forward(self, x):
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+        x = self.layer5(x)
+        x = x.view(x.size(0), -1)
+        x = self.fc(x)
+        return x

--- a/model_def.py
+++ b/model_def.py
@@ -50,7 +50,7 @@ class MyMEDMnistTrial(PyTorchTrial):
         num_epochs = self.context.get_experiment_config()["searcher"]["max_length"][
             "epochs"
         ]
-        milestones = [0.5 * num_epochs, 0.75 * num_epochs]
+        milestones = [int(0.5 * num_epochs), int(0.75 * num_epochs)]
         scheduler = torch.optim.lr_scheduler.MultiStepLR(
             self.optimizer,
             milestones=milestones,
@@ -127,7 +127,7 @@ class MyMEDMnistTrial(PyTorchTrial):
         self.context.backward(loss)
         self.context.step_optimizer(self.optimizer)
 
-        return {"loss": loss, "lr": self.optimizer.param_groups[0]["lr"]}
+        return {"loss": loss, "lr": self.lr_sch.get_last_lr()}
 
     def evaluate_batch(self, batch: TorchData) -> Dict[str, Any]:
         inputs, targets = batch

--- a/net.py
+++ b/net.py
@@ -1,0 +1,51 @@
+import torch.nn as nn
+
+
+# from https://github.com/MedMNIST/MedMNIST/blob/main/examples/getting_started.ipynb
+class Net(nn.Module):
+    def __init__(self, in_channels, num_classes):
+        super().__init__()
+
+        self.layer1 = nn.Sequential(
+            nn.Conv2d(in_channels, 16, kernel_size=3), nn.BatchNorm2d(16), nn.ReLU()
+        )
+
+        self.layer2 = nn.Sequential(
+            nn.Conv2d(16, 16, kernel_size=3),
+            nn.BatchNorm2d(16),
+            nn.ReLU(),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+        )
+
+        self.layer3 = nn.Sequential(
+            nn.Conv2d(16, 64, kernel_size=3), nn.BatchNorm2d(64), nn.ReLU()
+        )
+
+        self.layer4 = nn.Sequential(
+            nn.Conv2d(64, 64, kernel_size=3), nn.BatchNorm2d(64), nn.ReLU()
+        )
+
+        self.layer5 = nn.Sequential(
+            nn.Conv2d(64, 64, kernel_size=3, padding=1),
+            nn.BatchNorm2d(64),
+            nn.ReLU(),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+        )
+
+        self.fc = nn.Sequential(
+            nn.Linear(64 * 4 * 4, 128),
+            nn.ReLU(),
+            nn.Linear(128, 128),
+            nn.ReLU(),
+            nn.Linear(128, num_classes),
+        )
+
+    def forward(self, x):
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+        x = self.layer5(x)
+        x = x.view(x.size(0), -1)
+        x = self.fc(x)
+        return x

--- a/startup-hook.sh
+++ b/startup-hook.sh
@@ -1,1 +1,1 @@
-pip install -r requirements.txt
+pip install -r training_requirements.txt

--- a/training_requirements.txt
+++ b/training_requirements.txt
@@ -1,3 +1,2 @@
 medmnist
-tensorboardX
 wget

--- a/training_requirements.txt
+++ b/training_requirements.txt
@@ -1,0 +1,3 @@
+medmnist
+tensorboardX
+wget


### PR DESCRIPTION
The changes:
- Get rid of unused imports
- Format code, sort imports
- Add `.detignore` so that the user can run inference, run local tests etc, and still run training without `det` complaining about folder size
- Add `.gitignore`
- Separate the installation requirements for inference and training. The user manually installs the inference requirements, while the training requirements are installed in the startup-hook.
- Make the readme clearer in some places. I got rid of the `venv` stuff, since I feel like that is clutter and people use different environment managers, but it could be good to keep for people new to python.
- Use `retinamnist` because it's smaller, so training runs finish faster.
- Add `weight_decay`, `beta1`, and `beta2` as hyperparameters.
- Comment out the pathmnist aws data link from the config file. The code still allows for it to be used.
- Validate at the end of every epoch.
- Do a hyperparameter search.
- Remove `resize`, `model_flag`, `task`, and `num_epochs` from the config. The `num_epochs` is subjective, since using `self.context.get_experiment_config()["searcher"]["max_length"]["epochs"]` might not be supported in the future, but I think it's nicer than specifying the number of epochs twice.
- Use `Net` from [here](https://github.com/MedMNIST/MedMNIST/blob/main/examples/getting_started.ipynb), instead of ResNet18, for the sake of speed. The network is defined in `net.py`
- Minor changes to the inference scripts